### PR TITLE
Add Avaje+Robaho

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -62,6 +62,7 @@ jobs:
         if: steps.changes.outputs.skip == 'false'
         run: |
           mvn -ntp package -Pnative -DskipTests -f avaje-jex-jdk/pom.xml
+          mvn -ntp package -Pnative -DskipTests -f avaje-jex-robaho/pom.xml
           mvn -ntp package -Pnative native:compile -DskipTests -f spring-boot-web/pom.xml
           mvn -ntp package -Pnative native:compile -DskipTests -f spring-boot-webflux/pom.xml
           mvn -ntp package -Pnative,native-image -Dpackaging=native-image -DskipTests -f quarkus/pom.xml
@@ -79,6 +80,7 @@ jobs:
           title: Development Build
           files: |
             ./avaje-jex-jdk/target/avaje-jex-jdk
+            ./avaje-jex-robaho/target/avaje-jex-robaho
             ./quarkus/target/quarkus-demo-runner
             ./micronaut/target/micronaut-demo
             ./spring-boot-web/target/springboot-demo-web

--- a/avaje-jex-robaho/README
+++ b/avaje-jex-robaho/README
@@ -1,0 +1,15 @@
+# Avaje Jex Robaho Microservice Example
+
+This example demonstrates an ultralight microservice framework built using [Avaje Jex](https://avaje.io/jex/) and a [faster implementation of Java's built-in HttpServer](https://github.com/robaho/httpserver). It provides a lightweight, fast, and modern approach to building RESTful APIs and microservices.
+
+## Features
+
+- Compile-Time Dependency Injection
+- Jax Style Controllers via source code generation
+- Free of reflection
+- Fast startup and low memory footprint
+- Lightweight (Shaded jar is less than 3MB, when using the avaje json it's less than 1MB)
+
+## Documentation
+
+- [Avaje Documentation](https://avaje.io/)

--- a/avaje-jex-robaho/pom.xml
+++ b/avaje-jex-robaho/pom.xml
@@ -1,0 +1,126 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>io.avaje</groupId>
+		<artifactId>avaje-jex-parent</artifactId>
+		<version>3.2</version>
+	</parent>
+
+	<version>${parent.version}</version>
+	<artifactId>avaje-jex-robaho</artifactId>
+	<name>Avaje Jex Example</name>
+	<description>example avaje project</description>
+	<properties>
+		<maven.compiler.release>21</maven.compiler.release>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<mainClass>io.avaje.example.Main</mainClass>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>io.avaje</groupId>
+			<artifactId>avaje-http-api</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.avaje</groupId>
+			<artifactId>avaje-inject</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.avaje</groupId>
+			<artifactId>avaje-jex</artifactId>
+		</dependency>
+
+		<!-- enhanced JDK server impl-->
+		<dependency>
+			<groupId>io.github.robaho</groupId>
+			<artifactId>httpserver</artifactId>
+			<version>1.0.27</version>
+		</dependency>
+
+		<!-- processors-->
+		<dependency>
+			<groupId>io.avaje</groupId>
+			<artifactId>avaje-http-jex-generator</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.avaje</groupId>
+			<artifactId>avaje-inject-generator</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- jackson itself weighs more than all the avaje libraries combined -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<version>2.20.0</version>
+		</dependency>
+
+		<!-- avaje jsonb - uncomment if you want to use the lighter avaje jsonb
+		instead of jackson 
+		<dependency>
+			<groupId>io.avaje</groupId>
+			<artifactId>avaje-jsonb</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.avaje</groupId>
+			<artifactId>avaje-jsonb-generator</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		-->
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<transformers>
+								<transformer
+									implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+									<mainClass>${mainClass}</mainClass>
+								</transformer>
+							</transformers>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>native</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.graalvm.buildtools</groupId>
+						<artifactId>native-maven-plugin</artifactId>
+						<version>0.11.0</version>
+						<executions>
+							<execution>
+								<id>build-native</id>
+								<goals>
+									<goal>compile-no-fork</goal>
+								</goals>
+								<phase>package</phase>
+								<configuration>
+									<mainClass>${mainClass}</mainClass>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
+</project>

--- a/avaje-jex-robaho/pom.xml
+++ b/avaje-jex-robaho/pom.xml
@@ -10,7 +10,7 @@
 
 	<version>${parent.version}</version>
 	<artifactId>avaje-jex-robaho</artifactId>
-	<name>Avaje Jex Example</name>
+	<name>Avaje Jex Robaho Example</name>
 	<description>example avaje project</description>
 	<properties>
 		<maven.compiler.release>21</maven.compiler.release>

--- a/avaje-jex-robaho/src/main/java/io/avaje/example/Main.java
+++ b/avaje-jex-robaho/src/main/java/io/avaje/example/Main.java
@@ -1,0 +1,31 @@
+package io.avaje.example;
+
+import java.lang.System.Logger;
+
+import io.avaje.inject.BeanScope;
+import io.avaje.jex.Jex;
+import io.avaje.jex.Routing.HttpService;
+import io.avaje.jex.core.json.JacksonJsonService;
+
+/** The application main class. */
+public final class Main {
+
+  /**
+   * Application main entry point.
+   *
+   * @param args command line arguments.
+   */
+  public static void main(final String[] args) {
+    long start = System.currentTimeMillis();
+    var routes = BeanScope.builder().build().list(HttpService.class);
+    Jex.create()
+        .routing(routes)
+        //  .jsonService(new JsonbJsonService())
+        .jsonService(new JacksonJsonService())
+        .get("/simple-greet", ctx -> ctx.text("Hello World!"))
+        .start();
+    long end = System.currentTimeMillis();
+    System.getLogger("io.avaje.example.Main")
+        .log(Logger.Level.INFO, "Started in " + (end - start) + "ms");
+  }
+}

--- a/avaje-jex-robaho/src/main/java/io/avaje/example/RestController.java
+++ b/avaje-jex-robaho/src/main/java/io/avaje/example/RestController.java
@@ -1,0 +1,29 @@
+package io.avaje.example;
+
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+
+import io.avaje.http.api.Controller;
+import io.avaje.http.api.Get;
+
+@Controller
+public class RestController {
+  @Get("/hello")
+  public ApplicationInfo hello() {
+    return new ApplicationInfo("avaje-jex-jdk", LocalDate.now().getYear());
+  }
+
+  // @Json
+  @JsonAutoDetect(fieldVisibility = Visibility.ANY)
+  public static class ApplicationInfo {
+    ApplicationInfo(String name, int releaseYear) {
+      this.name = name;
+      this.releaseYear = releaseYear;
+    }
+
+    String name;
+    int releaseYear;
+  }
+}

--- a/avaje-jex-robaho/src/main/java/io/avaje/example/RestController.java
+++ b/avaje-jex-robaho/src/main/java/io/avaje/example/RestController.java
@@ -12,7 +12,7 @@ import io.avaje.http.api.Get;
 public class RestController {
   @Get("/hello")
   public ApplicationInfo hello() {
-    return new ApplicationInfo("avaje-jex-jdk", LocalDate.now().getYear());
+    return new ApplicationInfo("avaje-jex-robaho", LocalDate.now().getYear());
   }
 
   // @Json

--- a/avaje-jex-robaho/src/main/resources/META-INF/native-image/io.avaje/avaje-jex-parent/reachability-metadata.json
+++ b/avaje-jex-robaho/src/main/resources/META-INF/native-image/io.avaje/avaje-jex-parent/reachability-metadata.json
@@ -1,0 +1,86 @@
+{
+  "reflection": [
+    {
+      "type": "com.fasterxml.jackson.databind.ext.Java7SupportImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "io.avaje.config.Configuration"
+    },
+    {
+      "type": "io.avaje.example.ExampleModule"
+    },
+    {
+      "type": "io.avaje.example.RestController$ApplicationInfo",
+      "allDeclaredFields": true
+    },
+    {
+      "type": "io.avaje.http.inject.DefaultResolverProvider"
+    },
+    {
+      "type": "io.avaje.inject.events.spi.ObserverManagerPlugin"
+    },
+    {
+      "type": "java.lang.Class",
+      "methods": [
+        {
+          "name": "isRecord",
+          "parameterTypes": []
+        }
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/services/com.sun.net.httpserver.spi.HttpServerProvider"
+    },
+    {
+      "glob": "META-INF/services/io.avaje.applog.AppLog$Provider"
+    },
+    {
+      "glob": "META-INF/services/io.avaje.inject.spi.InjectExtension"
+    },
+    {
+      "glob": "META-INF/services/io.avaje.jex.spi.JexExtension"
+    },
+    {
+      "glob": "META-INF/services/java.lang.System$LoggerFinder"
+    },
+    {
+      "glob": "META-INF/services/java.net.spi.InetAddressResolverProvider"
+    },
+    {
+      "glob": "META-INF/services/java.nio.channels.spi.SelectorProvider"
+    },
+    {
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en.properties"
+    },
+    {
+      "module": "java.logging",
+      "glob": "sun/util/logging/resources/logging_en_GB.properties"
+    }
+  ],
+  "bundles": [],
+  "jni": [
+    {
+      "type": "java.lang.Boolean",
+      "methods": [
+        {
+          "name": "getBoolean",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/graph.html
+++ b/graph.html
@@ -9,7 +9,7 @@
         var dataSource = new google.visualization.arrayToDataTable([
             ['Framework', 'Response', 'Graal'],
             ["Avaje", AVAJE, GRAALA1VAJE],
-            ["Robaho", ROBAHO, GRAALROBAHO],
+            ["Robaho", ROBAHO, GRAALRO1BAHO],
             ["Spring", StartedDemoApplication, GRAALSPRING],
             ["Webflux", StartedDemoWebFluxApplication, GRAALWEBFLUX],
             ["Quarkus", QUARKUS, GRAALQ1UARKUS],

--- a/graph.html
+++ b/graph.html
@@ -9,6 +9,7 @@
         var dataSource = new google.visualization.arrayToDataTable([
             ['Framework', 'Response', 'Graal'],
             ["Avaje", AVAJE, GRAALA1VAJE],
+            ["Robaho", ROBAHO, GRAALROBAHO],
             ["Spring", StartedDemoApplication, GRAALSPRING],
             ["Webflux", StartedDemoWebFluxApplication, GRAALWEBFLUX],
             ["Quarkus", QUARKUS, GRAALQ1UARKUS],

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,8 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>avaje-jex-jdk</module>
+        <module>avaje-jex-robaho</module>
         <module>eclipse-microprofile-kumuluz-test</module>
         <module>helidon-se-netty</module>
         <module>ktor</module>
@@ -16,6 +18,5 @@
         <module>spring-boot-web</module>
         <module>vertx</module>
         <module>gatling</module>
-        <module>avaje-jex-jdk</module>
     </modules>
 </project>

--- a/runGatling.sh
+++ b/runGatling.sh
@@ -211,7 +211,7 @@ wget -qc https://github.com/ozkanpakdil/test-microservice-frameworks/releases/do
 chmod a+x avaje-jex-jdk avaje-jex-robaho quarkus-demo-runner micronaut-demo springboot-demo-web springboot-webflux-demo vertx-demo helidon-quickstart-se ktor-demo
 
 runNativeBinaryTests "./avaje-jex-jdk" "graalvm native avaje" "GRAALA1VAJE"
-runNativeBinaryTests "./avaje-jex-robaho" "graalvm native avaje" "GRAALROBAHO"
+runNativeBinaryTests "./avaje-jex-robaho" "graalvm native avaje" "GRAALRO1BAHO"
 runNativeBinaryTests "./quarkus-demo-runner" "graalvm native quarkus" "GRAALQ1UARKUS"
 runNativeBinaryTests "./micronaut-demo" "graalvm native micronaut" "GRAALM1ICRONAUT"
 runNativeBinaryTests "./springboot-demo-web" "graalvm native spring-boot-web" "GRAALSPRING"

--- a/runGatling.sh
+++ b/runGatling.sh
@@ -156,6 +156,7 @@ runNativeBinaryTests(){
 }
 
 test "avaje-jex-jdk/target/avaje-jex-jdk-$AVAJE.jar" "Avaje Jex started class sun.net.httpserver.HttpServerImpl" "AVAJE" "https://avaje.io/"
+test "avaje-jex-robaho/target/avaje-jex-robaho-$AVAJE.jar" "Avaje Jex started class robaho.net.httpserver.HttpServerImpl" "ROBAHO" "https://avaje.io/"
 test "spring-boot-webflux/target/springboot-webflux-demo-$SB.jar" ":: Spring Boot ::" "Started DemoWebFluxApplication" "https://spring.io/projects/spring-boot"
 test "spring-boot-web/target/springboot-demo-web-$SB.jar" ":: Spring Boot ::" "Started DemoApplication" "https://spring.io/projects/spring-boot"
 test "quarkus/target/quarkus-demo-runner.jar" "powered by Quarkus" "QUARKUS" "https://quarkus.io/"
@@ -197,7 +198,9 @@ runNativeBinaryTests "./Dotnet9Microservice" "Dotnet 9 rest service" "DOTNET9AOT
 
 ##### graalvm
 rm -rf avaje-jex-jdk
+rm -rf avaje-jex-robaho
 wget -qc https://github.com/ozkanpakdil/test-microservice-frameworks/releases/download/latest/avaje-jex-jdk
+wget -qc https://github.com/ozkanpakdil/test-microservice-frameworks/releases/download/latest/avaje-jex-robaho
 wget -qc https://github.com/ozkanpakdil/test-microservice-frameworks/releases/download/latest/quarkus-demo-runner
 wget -qc https://github.com/ozkanpakdil/test-microservice-frameworks/releases/download/latest/micronaut-demo
 wget -qc https://github.com/ozkanpakdil/test-microservice-frameworks/releases/download/latest/springboot-demo-web
@@ -205,9 +208,10 @@ wget -qc https://github.com/ozkanpakdil/test-microservice-frameworks/releases/do
 wget -qc https://github.com/ozkanpakdil/test-microservice-frameworks/releases/download/latest/vertx-demo
 wget -qc https://github.com/ozkanpakdil/test-microservice-frameworks/releases/download/latest/helidon-quickstart-se
 wget -qc https://github.com/ozkanpakdil/test-microservice-frameworks/releases/download/latest/ktor-demo
-chmod a+x avaje-jex-jdk quarkus-demo-runner micronaut-demo springboot-demo-web springboot-webflux-demo vertx-demo helidon-quickstart-se ktor-demo
+chmod a+x avaje-jex-jdk avaje-jex-robaho quarkus-demo-runner micronaut-demo springboot-demo-web springboot-webflux-demo vertx-demo helidon-quickstart-se ktor-demo
 
 runNativeBinaryTests "./avaje-jex-jdk" "graalvm native avaje" "GRAALA1VAJE"
+runNativeBinaryTests "./avaje-jex-jdk" "graalvm native avaje" "GRAALROBAHO"
 runNativeBinaryTests "./quarkus-demo-runner" "graalvm native quarkus" "GRAALQ1UARKUS"
 runNativeBinaryTests "./micronaut-demo" "graalvm native micronaut" "GRAALM1ICRONAUT"
 runNativeBinaryTests "./springboot-demo-web" "graalvm native spring-boot-web" "GRAALSPRING"

--- a/runGatling.sh
+++ b/runGatling.sh
@@ -211,7 +211,7 @@ wget -qc https://github.com/ozkanpakdil/test-microservice-frameworks/releases/do
 chmod a+x avaje-jex-jdk avaje-jex-robaho quarkus-demo-runner micronaut-demo springboot-demo-web springboot-webflux-demo vertx-demo helidon-quickstart-se ktor-demo
 
 runNativeBinaryTests "./avaje-jex-jdk" "graalvm native avaje" "GRAALA1VAJE"
-runNativeBinaryTests "./avaje-jex-jdk" "graalvm native avaje" "GRAALROBAHO"
+runNativeBinaryTests "./avaje-jex-robaho" "graalvm native avaje" "GRAALROBAHO"
 runNativeBinaryTests "./quarkus-demo-runner" "graalvm native quarkus" "GRAALQ1UARKUS"
 runNativeBinaryTests "./micronaut-demo" "graalvm native micronaut" "GRAALM1ICRONAUT"
 runNativeBinaryTests "./springboot-demo-web" "graalvm native spring-boot-web" "GRAALSPRING"

--- a/runGatling.sh
+++ b/runGatling.sh
@@ -156,7 +156,7 @@ runNativeBinaryTests(){
 }
 
 test "avaje-jex-jdk/target/avaje-jex-jdk-$AVAJE.jar" "Avaje Jex started class sun.net.httpserver.HttpServerImpl" "AVAJE" "https://avaje.io/"
-test "avaje-jex-robaho/target/avaje-jex-robaho-$AVAJE.jar" "Avaje Jex started class robaho.net.httpserver.HttpServerImpl" "ROBAHO" "https://avaje.io/"
+test "avaje-jex-robaho/target/avaje-jex-robaho-$AVAJE.jar" "started" "ROBAHO" "https://github.com/robaho/httpserver"
 test "spring-boot-webflux/target/springboot-webflux-demo-$SB.jar" ":: Spring Boot ::" "Started DemoWebFluxApplication" "https://spring.io/projects/spring-boot"
 test "spring-boot-web/target/springboot-demo-web-$SB.jar" ":: Spring Boot ::" "Started DemoApplication" "https://spring.io/projects/spring-boot"
 test "quarkus/target/quarkus-demo-runner.jar" "powered by Quarkus" "QUARKUS" "https://quarkus.io/"


### PR DESCRIPTION
By default, avaje would use the server that comes with the JDK. This new module replaces that with an actually good server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an ultralight microservice example with fast startup, low memory, a text /simple-greet endpoint and a JSON /hello endpoint; runnable native binary included.
- **Documentation**
  - Added README describing the example, features, and links to docs.
- **Tests**
  - Extended native/load performance tests to include the new binary variant.
- **Chores**
  - Updated build/release pipeline and root modules to include the new module (replacing the previous JDK-based module).
- **UI**
  - Updated performance graph with a new data series.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->