### PR TITLE
ci: use graalvm/setup-graalvm@v1.6.0 with version: 'latest' in runk6.yml

### DIFF
--- a/.github/workflows/runk6.yml
+++ b/.github/workflows/runk6.yml
@@ -16,9 +16,9 @@ jobs:
         java: [25]
     steps:
       - uses: actions/checkout@v4
-      - uses: graalvm/setup-graalvm@v1
+      - uses: graalvm/setup-graalvm@v1.6.0
         with:
-          version: '23.3.2'
+          version: 'latest'
           java-version: ${{ matrix.java }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           distribution: 'graalvm-community'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build workflow to use a newer GraalVM setup action and the latest GraalVM version for CI runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->