### PR TITLE
Fix/sdkman graalvm

### DIFF
--- a/.github/actions/install-graalvm/action.yml
+++ b/.github/actions/install-graalvm/action.yml
@@ -1,0 +1,62 @@
+name: Install GraalVM via SDKMAN
+
+description: "Installs GraalVM using SDKMAN and exposes JAVA_HOME and PATH.\nIf `candidate` is empty, picks the latest graalvm candidate from `sdk list java`."
+
+inputs:
+  candidate:
+    description: 'SDKMAN candidate identifier (optional). Empty = auto-pick latest graalvm candidate'
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install prerequisites
+      shell: bash
+      run: |
+        set -eux
+        sudo apt-get update
+        sudo apt-get install -y unzip zip curl jq grep sed awk
+    - name: Install SDKMAN
+      shell: bash
+      run: |
+        set -eux
+        curl -s "https://get.sdkman.io" | bash
+        # shellcheck disable=SC1091
+        source "$HOME/.sdkman/bin/sdkman-init.sh"
+    - name: Install GraalVM via SDKMAN
+      shell: bash
+      run: |
+        set -eux
+        # if candidate provided, use it
+        if [ -n "${{ inputs.candidate }}" ]; then
+          CANDIDATE="${{ inputs.candidate }}"
+          echo "Installing specific candidate: $CANDIDATE"
+          sdk install java "$CANDIDATE" || true
+          sdk default java "$CANDIDATE"
+        else
+          echo "No candidate provided; picking latest graalvm candidate from 'sdk list java'"
+          LATEST=$(sdk list java | awk '/graalvm/ {gsub(/^[ \t]+|[ \t]+$/,""); print $NF}' | head -n1)
+          if [ -z "$LATEST" ]; then
+            echo "No GraalVM candidate found via sdk list java" >&2
+            sdk list java
+            exit 1
+          fi
+          echo "Latest candidate: $LATEST"
+          sdk install java "$LATEST" || true
+          sdk default java "$LATEST"
+        fi
+        export JAVA_HOME="$HOME/.sdkman/candidates/java/current"
+        export PATH="$JAVA_HOME/bin:$PATH"
+        echo "JAVA_HOME=$JAVA_HOME" >> $GITHUB_ENV
+        echo "PATH=$JAVA_HOME/bin:$PATH" >> $GITHUB_ENV
+        java -version || true
+    - name: Install native-image (if available)
+      shell: bash
+      run: |
+        set -eux
+        if command -v gu >/dev/null 2>&1; then
+          gu install native-image || true
+        else
+          echo "gu not available; native-image install skipped"
+        fi

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -68,14 +68,10 @@ jobs:
               fi
             fi
           fi
-      - uses: graalvm/setup-graalvm@v1.6.0
+      - uses: ./.github/actions/install-graalvm
         if: steps.changes.outputs.skip == 'false'
         with:
-          version: 'latest'
-          java-version: ${{ matrix.java }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          native-image-job-reports: 'true'
-          distribution: 'graalvm-community'
+          candidate: ''
       - name: Set up Go
         if: steps.changes.outputs.skip == 'false'
         uses: actions/setup-go@v5

--- a/.github/workflows/rungatling.yml
+++ b/.github/workflows/rungatling.yml
@@ -16,13 +16,9 @@ jobs:
         java: [25]
     steps:
       - uses: actions/checkout@v4
-      - uses: graalvm/setup-graalvm@v1.6.0
+      - uses: ./.github/actions/install-graalvm
         with:
-          version: 'latest'
-          java-version: ${{ matrix.java }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          distribution: 'graalvm-community'
-          native-image-job-reports: 'true'
+          candidate: ''
       # - name: Set up JDK
       #   uses: actions/setup-java@v3
       #   with:
@@ -91,4 +87,3 @@ jobs:
 #          # Hugo builds to hugo/public when using `-s hugo -d public`
 #          # GitHub Pages cannot select an arbitrary folder like /hugo; when using the gh-pages branch, choose folder /
 #          publish_dir: ./hugo/public
-

--- a/.github/workflows/runk6.yml
+++ b/.github/workflows/runk6.yml
@@ -16,13 +16,9 @@ jobs:
         java: [25]
     steps:
       - uses: actions/checkout@v4
-      - uses: graalvm/setup-graalvm@v1.6.0
+      - uses: ./.github/actions/install-graalvm
         with:
-          version: 'latest'
-          java-version: ${{ matrix.java }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          distribution: 'graalvm-community'
-          native-image-job-reports: 'true'
+          candidate: ''
       # - name: Set up JDK
       #   uses: actions/setup-java@v3
       #   with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a reusable setup step for GraalVM in CI.
  * Updated multiple workflows to use the shared setup, making Java environment provisioning more consistent.
  * The new setup can automatically pick a GraalVM candidate and prepares `JAVA_HOME` and `PATH` for subsequent steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->